### PR TITLE
Update Taavi's apt repository

### DIFF
--- a/apt/sources.list.d/majava.sources
+++ b/apt/sources.list.d/majava.sources
@@ -1,0 +1,5 @@
+Types: deb deb-src
+URIs: https://apt.majava.org
+Suites: bookworm
+Components: main
+Signed-By: /usr/share/keyrings/majava-apt.asc

--- a/apt/sources.list.d/taavi.sources
+++ b/apt/sources.list.d/taavi.sources
@@ -1,5 +1,0 @@
-Types: deb deb-src
-URIs: https://apt.taavi.wtf
-Suites: bookworm
-Components: main
-Signed-By: /usr/share/keyrings/taavi-apt.asc


### PR DESCRIPTION
I'm consolidating some of my infrastructure, apt.taavi.wtf is being
retired and merged to apt.majava.org. The taavi-keyring (now
majava-keyring) package has been updated for apt.majava.org as well, so
it should work out of the box as long as you upgrade that before
applying this patch.
